### PR TITLE
Update SocialMetaTagsExtension.php

### DIFF
--- a/src/SocialMetaTagsExtension.php
+++ b/src/SocialMetaTagsExtension.php
@@ -30,9 +30,16 @@ class SocialMetaTagsExtension extends DataExtension {
     public function updateCMSFields(FieldList $fields) {
         $owner = $this->getOwner();
 
-        if (is_subclass_of($owner, SiteTree::class) && !is_a($owner, RedirectorPage::class)) {
-            $fields->addFieldToTab('Root.Main.Metadata', TextareaField::create("SocialMetaDescription")->addExtraClass("stacked"));
-            $fields->addFieldToTab('Root.Main.Metadata', UploadField::create("SocialMetaImage")->addExtraClass("stacked"));
+        if (is_subclass_of($owner, SiteTree::class)) {
+            if (!is_a($owner, RedirectorPage::class)) {
+                $fields->addFieldToTab('Root.Main.Metadata', TextareaField::create("SocialMetaDescription")->addExtraClass("stacked"));
+                $fields->addFieldToTab('Root.Main.Metadata', UploadField::create("SocialMetaImage")->addExtraClass("stacked"));
+            }
+            else {
+                $fields->removeByName("H1");
+                $fields->removeByName("PageTitle");
+                $fields->removeByName("MetaKeywords");
+            }
         }
     }
 


### PR DESCRIPTION
Hides fields on redirector pages that don't need to be there.